### PR TITLE
string_types not needed anymore in mkdocs 1.1

### DIFF
--- a/pheasant/plugins/mkdocs.py
+++ b/pheasant/plugins/mkdocs.py
@@ -9,7 +9,7 @@ import yaml
 from mkdocs.config import config_options
 from mkdocs.plugins import BasePlugin
 from mkdocs.structure.files import get_files
-from mkdocs.utils import markdown_extensions, string_types
+from mkdocs.utils import markdown_extensions
 
 import pheasant
 from pheasant.core.pheasant import Pheasant
@@ -23,7 +23,7 @@ class PheasantPlugin(BasePlugin):
     config_scheme = (
         ("jupyter", config_options.Type(bool, default=True)),
         ("dirty", config_options.Type(bool, default=True)),
-        ("version", config_options.Type(string_types, default="")),
+        ("version", config_options.Type(str, default="")),
         ("header", config_options.Type(dict, default={})),
     )
     converter = Pheasant()


### PR DESCRIPTION
See https://github.com/mkdocs/mkdocs/blob/1.0.4/mkdocs/utils/__init__.py

MkDocs 1.1 dropped support for python 2, supporting only 3.5+. 

We could remove `string_types`